### PR TITLE
[OP] chore: remove unused activated_height

### DIFF
--- a/contracts/op-finality-gadget/schema/op-finality-gadget.json
+++ b/contracts/op-finality-gadget/schema/op-finality-gadget.json
@@ -7,17 +7,11 @@
     "title": "InstantiateMsg",
     "type": "object",
     "required": [
-      "activated_height",
       "admin",
       "consumer_id",
       "is_enabled"
     ],
     "properties": {
-      "activated_height": {
-        "type": "integer",
-        "format": "uint64",
-        "minimum": 0.0
-      },
       "admin": {
         "type": "string"
       },
@@ -374,15 +368,9 @@
       "description": "Config are OP finality gadget's configuration",
       "type": "object",
       "required": [
-        "activated_height",
         "consumer_id"
       ],
       "properties": {
-        "activated_height": {
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0.0
-        },
         "consumer_id": {
           "type": "string"
         }

--- a/contracts/op-finality-gadget/schema/raw/instantiate.json
+++ b/contracts/op-finality-gadget/schema/raw/instantiate.json
@@ -3,17 +3,11 @@
   "title": "InstantiateMsg",
   "type": "object",
   "required": [
-    "activated_height",
     "admin",
     "consumer_id",
     "is_enabled"
   ],
   "properties": {
-    "activated_height": {
-      "type": "integer",
-      "format": "uint64",
-      "minimum": 0.0
-    },
     "admin": {
       "type": "string"
     },

--- a/contracts/op-finality-gadget/schema/raw/response_to_config.json
+++ b/contracts/op-finality-gadget/schema/raw/response_to_config.json
@@ -4,15 +4,9 @@
   "description": "Config are OP finality gadget's configuration",
   "type": "object",
   "required": [
-    "activated_height",
     "consumer_id"
   ],
   "properties": {
-    "activated_height": {
-      "type": "integer",
-      "format": "uint64",
-      "minimum": 0.0
-    },
     "consumer_id": {
       "type": "string"
     }

--- a/contracts/op-finality-gadget/src/contract.rs
+++ b/contracts/op-finality-gadget/src/contract.rs
@@ -23,7 +23,6 @@ pub fn instantiate(
 
     let config = Config {
         consumer_id: msg.consumer_id,
-        activated_height: msg.activated_height,
     };
     CONFIG.save(deps.storage, &config)?;
 
@@ -117,13 +116,11 @@ pub(crate) mod tests {
         let mut deps = mock_dependencies();
         let init_admin = deps.api.addr_make(INIT_ADMIN);
         let consumer_id = "op".to_string();
-        let activated_height = 1000;
 
         // Create an InstantiateMsg with admin set to init_admin
         let msg = InstantiateMsg {
             admin: init_admin.to_string(),
             consumer_id,
-            activated_height,
             is_enabled: true,
         };
 
@@ -153,7 +150,6 @@ pub(crate) mod tests {
         let instantiate_msg = InstantiateMsg {
             admin: init_admin.to_string(), // Admin provided
             consumer_id: "op-stack-l2-11155420".to_string(),
-            activated_height: 13513311,
             is_enabled: true,
         };
 

--- a/contracts/op-finality-gadget/src/msg.rs
+++ b/contracts/op-finality-gadget/src/msg.rs
@@ -13,7 +13,6 @@ use babylon_merkle::Proof;
 pub struct InstantiateMsg {
     pub admin: String,
     pub consumer_id: String,
-    pub activated_height: u64,
     pub is_enabled: bool,
 }
 

--- a/contracts/op-finality-gadget/src/state/config.rs
+++ b/contracts/op-finality-gadget/src/state/config.rs
@@ -11,6 +11,4 @@ pub const IS_ENABLED: Item<bool> = Item::new("is_enabled");
 #[cw_serde]
 pub struct Config {
     pub consumer_id: String,
-    // activated_height is the consumer chain block height at which the finality gadget is activated
-    pub activated_height: u64,
 }

--- a/contracts/op-finality-gadget/tests/integration.rs
+++ b/contracts/op-finality-gadget/tests/integration.rs
@@ -18,7 +18,6 @@ fn instantiate_works() {
     let msg = InstantiateMsg {
         admin: mock_api.addr_make(CREATOR),
         consumer_id: "op-stack-l2-11155420".to_string(),
-        activated_height: 13513311,
         is_enabled: false,
     };
     let info = mock_info(CREATOR, &[]);
@@ -30,7 +29,6 @@ fn instantiate_works() {
     let res: Config =
         from_json(query(&mut deps, mock_env(), QueryMsg::Config {}).unwrap()).unwrap();
     assert_eq!(msg.consumer_id, res.consumer_id);
-    assert_eq!(msg.activated_height, res.activated_height);
 
     // Check the admin is properly stored in the state and returned
     let res: AdminResponse =
@@ -51,7 +49,6 @@ fn disable_and_reenable_works() {
     let msg = InstantiateMsg {
         admin: mock_api.addr_make(CREATOR),
         consumer_id: "op-stack-l2-11155420".to_string(),
-        activated_height: 13513311,
         is_enabled: false,
     };
     let info = mock_info(CREATOR, &[]);
@@ -111,7 +108,6 @@ fn instantiate_enabled() {
     let msg = InstantiateMsg {
         admin: mock_api.addr_make(CREATOR),
         consumer_id: "op-stack-l2-11155420".to_string(),
-        activated_height: 13513311,
         is_enabled: true,
     };
     let info = mock_info(CREATOR, &[]);


### PR DESCRIPTION
## Summary

after https://github.com/babylonlabs-io/finality-provider/pull/42, we no longer need to read activated height from the cw contract.

instead, we properly find the time when the first delegation became active (see https://github.com/babylonchain/finality-provider/issues/432)

so this cleans up the unused field

## Test Plan

```
cargo optimize
cargo precommit
cargo integration
cargo test
```