### PR TITLE
F/rewards distribution

### DIFF
--- a/contracts/btc-finality/src/contract.rs
+++ b/contracts/btc-finality/src/contract.rs
@@ -91,8 +91,8 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<QueryResponse, Cont
         QueryMsg::Config {} => Ok(to_json_binary(&queries::config(deps)?)?),
         QueryMsg::Params {} => Ok(to_json_binary(&queries::params(deps)?)?),
         QueryMsg::Admin {} => to_json_binary(&ADMIN.query_admin(deps)?).map_err(Into::into),
-        QueryMsg::FinalitySignature { btc_pk_hex, height } => Ok(to_json_binary(
-            &queries::finality_signature(deps, btc_pk_hex, height)?,
+        QueryMsg::FinalityVote { btc_pk_hex, height } => Ok(to_json_binary(
+            &queries::finality_vote(deps, btc_pk_hex, height)?,
         )?),
         QueryMsg::PubRandCommit {
             btc_pk_hex,

--- a/contracts/btc-finality/src/contract.rs
+++ b/contracts/btc-finality/src/contract.rs
@@ -13,7 +13,8 @@ use btc_staking::msg::ActivatedHeightResponse;
 
 use crate::error::ContractError;
 use crate::finality::{
-    compute_active_finality_providers, handle_finality_signature, handle_public_randomness_commit,
+    compute_active_finality_providers, distribute_rewards, handle_finality_signature,
+    handle_public_randomness_commit,
 };
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use crate::state::config::{Config, ADMIN, CONFIG, PARAMS};
@@ -222,6 +223,9 @@ fn handle_update_staking(
 }
 
 fn handle_begin_block(deps: &mut DepsMut, env: Env) -> Result<Response<BabylonMsg>, ContractError> {
+    // Distribute rewards of the previous block
+    distribute_rewards(deps, env.block.height - 1)?;
+
     // Compute active finality provider set
     let max_active_fps = PARAMS.load(deps.storage)?.max_active_finality_providers as usize;
     compute_active_finality_providers(deps, env, max_active_fps)?;

--- a/contracts/btc-finality/src/finality.rs
+++ b/contracts/btc-finality/src/finality.rs
@@ -1,7 +1,7 @@
 use crate::contract::encode_smart_query;
 use crate::error::ContractError;
 use crate::state::config::{Config, CONFIG, PARAMS};
-use crate::state::finality::{BLOCKS, EVIDENCES, FP_SET, NEXT_HEIGHT, SIGNATURES, TOTAL_POWER};
+use crate::state::finality::{BLOCKS, EVIDENCES, FP_SET, NEXT_HEIGHT, SIGNATURES};
 use crate::state::public_randomness::{
     get_last_pub_rand_commit, get_pub_rand_commit_for_height, PUB_RAND_COMMITS, PUB_RAND_VALUES,
 };
@@ -603,8 +603,6 @@ pub fn compute_active_finality_providers(
     // Save the new set of active finality providers
     // TODO: Purge old (height - finality depth) FP_SET entries to avoid bloating the storage
     FP_SET.save(deps.storage, env.block.height, &finality_providers)?;
-    // Save the total voting power of the top n finality providers
-    TOTAL_POWER.save(deps.storage, &total_power)?;
 
     Ok(())
 }

--- a/contracts/btc-finality/src/msg.rs
+++ b/contracts/btc-finality/src/msg.rs
@@ -30,10 +30,10 @@ pub enum QueryMsg {
     /// `Admin` returns the current admin of the contract
     #[returns(AdminResponse)]
     Admin {},
-    /// `FinalitySignature` returns the signature of the finality provider for a given block height
+    /// `FinalityVote` returns the vote of the finality provider for a given block height
     ///
-    #[returns(FinalitySignatureResponse)]
-    FinalitySignature { btc_pk_hex: String, height: u64 },
+    #[returns(FinalityVoteResponse)]
+    FinalityVote { btc_pk_hex: String, height: u64 },
     /// `PubRandCommit` returns the public random commitments for a given FP.
     ///
     /// `btc_pk_hex` is the BTC public key of the finality provider, in hex format.
@@ -89,8 +89,9 @@ pub enum QueryMsg {
 }
 
 #[cw_serde]
-pub struct FinalitySignatureResponse {
+pub struct FinalityVoteResponse {
     pub signature: Vec<u8>,
+    pub voting_power: u64,
 }
 
 #[cw_serde]

--- a/contracts/btc-finality/src/multitest.rs
+++ b/contracts/btc-finality/src/multitest.rs
@@ -37,7 +37,6 @@ mod instantiation {
 mod finality {
     use super::*;
 
-    use crate::msg::FinalitySignatureResponse;
     use babylon_apis::finality_api::IndexedBlock;
     use test_utils::get_public_randomness_commitment;
 
@@ -150,14 +149,10 @@ mod finality {
             )
             .unwrap();
 
-        // Query finality signature for that exact height
-        let sig = suite.get_finality_signature(&pk_hex, initial_height + 1);
-        assert_eq!(
-            sig,
-            FinalitySignatureResponse {
-                signature: finality_sig
-            }
-        );
+        // Query finality vote for that exact height
+        let sig = suite.get_finality_vote(&pk_hex, initial_height + 1);
+        // Assert the vote signature is correct
+        assert_eq!(sig.signature, finality_sig);
     }
 
     #[test]

--- a/contracts/btc-finality/src/multitest/suite.rs
+++ b/contracts/btc-finality/src/multitest/suite.rs
@@ -15,7 +15,7 @@ use babylon_bitcoin::chain_params::Network;
 
 use btc_staking::msg::{ActivatedHeightResponse, FinalityProviderInfo};
 
-use crate::msg::{EvidenceResponse, FinalitySignatureResponse};
+use crate::msg::{EvidenceResponse, FinalityVoteResponse};
 use crate::multitest::{CONTRACT1_ADDR, CONTRACT2_ADDR};
 
 fn contract_btc_staking() -> Box<dyn Contract<BabylonMsg>> {
@@ -219,12 +219,12 @@ impl Suite {
     }
 
     #[track_caller]
-    pub fn get_finality_signature(&self, pk_hex: &str, height: u64) -> FinalitySignatureResponse {
+    pub fn get_finality_vote(&self, pk_hex: &str, height: u64) -> FinalityVoteResponse {
         self.app
             .wrap()
             .query_wasm_smart(
                 self.finality.clone(),
-                &crate::msg::QueryMsg::FinalitySignature {
+                &crate::msg::QueryMsg::FinalityVote {
                     btc_pk_hex: pk_hex.to_string(),
                     height,
                 },

--- a/contracts/btc-finality/src/queries.rs
+++ b/contracts/btc-finality/src/queries.rs
@@ -5,10 +5,10 @@ use cw_storage_plus::Bound;
 use babylon_apis::finality_api::IndexedBlock;
 
 use crate::error::ContractError;
-use crate::msg::{BlocksResponse, EvidenceResponse, FinalitySignatureResponse};
+use crate::msg::{BlocksResponse, EvidenceResponse, FinalityVoteResponse};
 use crate::state::config::{Config, Params};
 use crate::state::config::{CONFIG, PARAMS};
-use crate::state::finality::{BLOCKS, EVIDENCES, SIGNATURES};
+use crate::state::finality::{BLOCKS, EVIDENCES, VOTES};
 
 pub fn config(deps: Deps) -> StdResult<Config> {
     CONFIG.load(deps.storage)
@@ -22,15 +22,19 @@ pub fn params(deps: Deps) -> StdResult<Params> {
 const MAX_LIMIT: u32 = 30;
 const DEFAULT_LIMIT: u32 = 10;
 
-pub fn finality_signature(
+pub fn finality_vote(
     deps: Deps,
     btc_pk_hex: String,
     height: u64,
-) -> StdResult<FinalitySignatureResponse> {
-    match SIGNATURES.may_load(deps.storage, (height, &btc_pk_hex))? {
-        Some(sig) => Ok(FinalitySignatureResponse { signature: sig }),
-        None => Ok(FinalitySignatureResponse {
+) -> StdResult<FinalityVoteResponse> {
+    match VOTES.may_load(deps.storage, (height, &btc_pk_hex))? {
+        Some(sig) => Ok(FinalityVoteResponse {
+            signature: sig.signature,
+            voting_power: sig.voting_power,
+        }),
+        None => Ok(FinalityVoteResponse {
             signature: Vec::new(),
+            voting_power: 0,
         }), // Empty signature response
     }
 }

--- a/contracts/btc-finality/src/state/finality.rs
+++ b/contracts/btc-finality/src/state/finality.rs
@@ -1,4 +1,5 @@
 use cosmwasm_schema::cw_serde;
+use cosmwasm_std::Uint128;
 use cw_storage_plus::{Item, Map};
 
 use babylon_apis::finality_api::{Evidence, IndexedBlock};
@@ -25,3 +26,9 @@ pub const FP_SET: Map<u64, Vec<FinalityProviderInfo>> = Map::new("fp_set");
 
 /// Map of double signing evidence by FP and block height
 pub const EVIDENCES: Map<(&str, u64), Evidence> = Map::new("evidences");
+
+/// Map of pending finality provider rewards
+pub const REWARDS: Map<&str, Uint128> = Map::new("rewards");
+
+/// Total pending rewards
+pub const TOTAL_REWARDS: Item<Uint128> = Item::new("total_rewards");

--- a/contracts/btc-finality/src/state/finality.rs
+++ b/contracts/btc-finality/src/state/finality.rs
@@ -1,10 +1,18 @@
+use cosmwasm_schema::cw_serde;
 use cw_storage_plus::{Item, Map};
 
 use babylon_apis::finality_api::{Evidence, IndexedBlock};
 use btc_staking::msg::FinalityProviderInfo;
 
-/// Map of signatures by block height and FP
-pub const SIGNATURES: Map<(u64, &str), Vec<u8>> = Map::new("fp_sigs");
+/// Finality provider vote, with the signature and voting power
+#[cw_serde]
+pub struct Vote {
+    pub signature: Vec<u8>,
+    pub voting_power: u64,
+}
+
+/// Map of votes by block height and FP
+pub const VOTES: Map<(u64, &str), Vote> = Map::new("fp_votes");
 
 /// Map of blocks information by height
 pub const BLOCKS: Map<u64, IndexedBlock> = Map::new("blocks");

--- a/contracts/btc-finality/src/state/finality.rs
+++ b/contracts/btc-finality/src/state/finality.rs
@@ -15,9 +15,5 @@ pub const NEXT_HEIGHT: Item<u64> = Item::new("next_height");
 /// `FP_SET` is the calculated list of the active finality providers by height
 pub const FP_SET: Map<u64, Vec<FinalityProviderInfo>> = Map::new("fp_set");
 
-/// `TOTAL_POWER` is the total power of all finality providers
-// FIXME: Store by height? Remove? Not currently being used in the contract
-pub const TOTAL_POWER: Item<u64> = Item::new("total_power");
-
 /// Map of double signing evidence by FP and block height
 pub const EVIDENCES: Map<(&str, u64), Evidence> = Map::new("evidences");


### PR DESCRIPTION
Implements first level (across FPs) rewards distribution.

This is an initial / naïve impl of rewards distribution. It will likely need to be extended / augmented to support better distribution for late finality votes, and / or depending on the active set instead of the voting table.