### PR TITLE
feat: op consumer chain slashing (2/2)

### DIFF
--- a/contracts/op-finality-gadget/src/contract.rs
+++ b/contracts/op-finality-gadget/src/contract.rs
@@ -89,7 +89,7 @@ pub fn execute(
             &block_hash,
             &signature,
         ),
-        ExecuteMsg::Slashing { evidence } => handle_slashing(&evidence),
+        ExecuteMsg::Slashing { env, evidence } => handle_slashing(&env, &evidence),
         ExecuteMsg::SetEnabled { enabled } => set_enabled(deps, info, enabled),
         ExecuteMsg::UpdateAdmin { admin } => ADMIN
             .execute_update_admin(deps, info, Some(api.addr_validate(&admin)?))

--- a/contracts/op-finality-gadget/src/contract.rs
+++ b/contracts/op-finality-gadget/src/contract.rs
@@ -82,6 +82,7 @@ pub fn execute(
         } => handle_finality_signature(
             deps,
             env,
+            info,
             &fp_pubkey_hex,
             height,
             &pub_rand,
@@ -89,7 +90,7 @@ pub fn execute(
             &block_hash,
             &signature,
         ),
-        ExecuteMsg::Slashing { env, evidence } => handle_slashing(&env, &evidence),
+        ExecuteMsg::Slashing { sender, evidence } => handle_slashing(&sender, &evidence),
         ExecuteMsg::SetEnabled { enabled } => set_enabled(deps, info, enabled),
         ExecuteMsg::UpdateAdmin { admin } => ADMIN
             .execute_update_admin(deps, info, Some(api.addr_validate(&admin)?))

--- a/contracts/op-finality-gadget/src/exec/finality.rs
+++ b/contracts/op-finality-gadget/src/exec/finality.rs
@@ -13,7 +13,9 @@ use babylon_bindings::BabylonMsg;
 
 use babylon_apis::finality_api::{Evidence, PubRandCommit};
 use babylon_merkle::Proof;
-use cosmwasm_std::{to_json_binary, Deps, DepsMut, Env, Event, Response, WasmMsg};
+use cosmwasm_std::{
+    to_json_binary, Addr, Deps, DepsMut, Env, Event, MessageInfo, Response, WasmMsg,
+};
 use k256::ecdsa::signature::Verifier;
 use k256::schnorr::{Signature, VerifyingKey};
 use k256::sha2::{Digest, Sha256};
@@ -114,6 +116,7 @@ pub(crate) fn verify_commitment_signature(
 pub fn handle_finality_signature(
     deps: DepsMut,
     env: Env,
+    info: MessageInfo,
     fp_btc_pk_hex: &str,
     height: u64,
     pub_rand: &[u8],
@@ -211,7 +214,7 @@ pub fn handle_finality_signature(
 
         // slash this finality provider, including setting its voting power to
         // zero, extracting its BTC SK, and emit an event
-        let (msg, ev) = slash_finality_provider(&env, fp_btc_pk_hex, &evidence)?;
+        let (msg, ev) = slash_finality_provider(&env, &info, fp_btc_pk_hex, &evidence)?;
         res = res.add_message(msg);
         res = res.add_event(ev);
     }
@@ -311,6 +314,7 @@ fn check_fp_exist(deps: Deps, fp_pubkey_hex: &str) -> Result<(), ContractError> 
 /// its voting power to zero, extracting its BTC SK, and emitting an event
 fn slash_finality_provider(
     env: &Env,
+    info: &MessageInfo,
     fp_btc_pk_hex: &str,
     evidence: &Evidence,
 ) -> Result<(WasmMsg, Event), ContractError> {
@@ -328,7 +332,7 @@ fn slash_finality_provider(
     // Emit slashing event.
     // Raises slashing event to babylon over IBC.
     let msg = ExecuteMsg::Slashing {
-        env: env.clone(),
+        sender: info.sender.clone(),
         evidence: evidence.clone(),
     };
     let wasm_msg: WasmMsg = WasmMsg::Execute {
@@ -359,14 +363,14 @@ fn slash_finality_provider(
 }
 
 pub(crate) fn handle_slashing(
-    env: &Env,
+    sender: &Addr,
     evidence: &Evidence,
 ) -> Result<Response<BabylonMsg>, ContractError> {
     let mut res = Response::new();
     // Send msg to Babylon
 
     let msg = BabylonMsg::EquivocationEvidence {
-        signer: env.contract.address.to_string(),
+        signer: sender.to_string(),
         fp_btc_pk: evidence.fp_btc_pk.clone(),
         block_height: evidence.block_height,
         pub_rand: evidence.pub_rand.clone(),
@@ -387,8 +391,9 @@ pub(crate) fn handle_slashing(
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use cosmwasm_std::from_json;
     use cosmwasm_std::testing::mock_env;
+    use cosmwasm_std::Addr;
+    use cosmwasm_std::{from_json, testing::message_info};
     use std::collections::HashMap;
 
     use babylon_apis::finality_api::PubRandCommit;
@@ -482,9 +487,9 @@ pub(crate) mod tests {
 
         // Create mock environment
         let env = mock_env(); // You'll need to add this mock helper
-
+        let info = message_info(&Addr::unchecked("test"), &[]);
         // Test slash_finality_provider
-        let (wasm_msg, event) = slash_finality_provider(&env, &pk_hex, &evidence).unwrap();
+        let (wasm_msg, event) = slash_finality_provider(&env, &info, &pk_hex, &evidence).unwrap();
 
         // Verify the WasmMsg is correctly constructed
         match wasm_msg {
@@ -498,7 +503,7 @@ pub(crate) mod tests {
                 let msg_evidence = from_json::<ExecuteMsg>(&msg).unwrap();
                 match msg_evidence {
                     ExecuteMsg::Slashing {
-                        env: _,
+                        sender: _,
                         evidence: msg_evidence,
                     } => {
                         assert_eq!(evidence, msg_evidence);

--- a/contracts/op-finality-gadget/src/msg.rs
+++ b/contracts/op-finality-gadget/src/msg.rs
@@ -6,7 +6,7 @@ use {
 
 use babylon_apis::finality_api::Evidence;
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Binary, Env};
+use cosmwasm_std::{Addr, Binary};
 
 use babylon_merkle::Proof;
 
@@ -80,7 +80,7 @@ pub enum ExecuteMsg {
     ///
     /// This message can be called by the admin only.
     Slashing {
-        env: Env,
+        sender: Addr,
         evidence: Evidence,
     },
     /// Enable or disable finality gadget.

--- a/contracts/op-finality-gadget/src/msg.rs
+++ b/contracts/op-finality-gadget/src/msg.rs
@@ -6,7 +6,7 @@ use {
 
 use babylon_apis::finality_api::Evidence;
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::Binary;
+use cosmwasm_std::{Binary, Env};
 
 use babylon_merkle::Proof;
 
@@ -80,6 +80,7 @@ pub enum ExecuteMsg {
     ///
     /// This message can be called by the admin only.
     Slashing {
+        env: Env,
         evidence: Evidence,
     },
     /// Enable or disable finality gadget.

--- a/packages/bindings/src/msg.rs
+++ b/packages/bindings/src/msg.rs
@@ -3,9 +3,9 @@
 //! - ForkHeader: reporting a fork that has a valid quorum certificate
 //! - FinalizedHeader: reporting a BTC-finalised header.
 
-use babylon_apis::finality_api::Evidence;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Coin, CosmosMsg, Empty};
+
 /// BabylonMsg is the message that the Babylon contract can send to the Cosmos zone.
 /// The Cosmos zone has to integrate https://github.com/babylonlabs-io/wasmbinding for
 /// handling these messages
@@ -21,17 +21,39 @@ pub enum BabylonMsg {
     /// It can only be sent from the finality contract.
     /// The rewards are minted to the staking contract address, so that they
     /// can be distributed across the active finality provider set
-    MintRewards {
-        amount: Coin,
-        recipient: String,
-    },
+    MintRewards { amount: Coin, recipient: String },
+    /// EquivocationEvidence is the message that the Babylon contract sends to Babylon
+    /// to notify it of consumer chain slashing.
     EquivocationEvidence {
-        evidence: Option<Evidence>,
+        /// `signer` is the address submitting the evidence
+        signer: String,
+        /// `fp_btc_pk` is the BTC PK of the finality provider that casts this vote
+        fp_btc_pk: Bytes,
+        /// `block_height` is the height of the conflicting blocks
+        block_height: u64,
+        /// `pub_rand is` the public randomness the finality provider has committed to.
+        /// Deserializes to `SchnorrPubRand`
+        pub_rand: Bytes,
+        /// `canonical_app_hash` is the AppHash of the canonical block
+        canonical_app_hash: Bytes,
+        /// `fork_app_hash` is the AppHash of the fork block
+        fork_app_hash: Bytes,
+        /// `canonical_finality_sig` is the finality signature to the canonical block,
+        /// where finality signature is an EOTS signature, i.e.,
+        /// the `s` in a Schnorr signature `(r, s)`.
+        /// `r` is the public randomness already committed by the finality provider.
+        /// Deserializes to `SchnorrEOTSSig`
+        canonical_finality_sig: Bytes,
+        /// `fork_finality_sig` is the finality signature to the fork block,
+        /// where finality signature is an EOTS signature.
+        /// Deserializes to `SchnorrEOTSSig`
+        fork_finality_sig: Bytes,
     },
 }
 
 pub type BabylonSudoMsg = Empty;
 pub type BabylonQuery = Empty;
+pub type Bytes = Vec<u8>;
 
 // make BabylonMsg to implement CosmosMsg::CustomMsg
 impl cosmwasm_std::CustomMsg for BabylonMsg {}

--- a/packages/bindings/src/msg.rs
+++ b/packages/bindings/src/msg.rs
@@ -28,14 +28,14 @@ pub enum BabylonMsg {
         /// `signer` is the address submitting the evidence
         signer: String,
         /// `fp_btc_pk` is the BTC PK of the finality provider that casts this vote
-        fp_btc_pk: Bytes,
+        fp_btc_pk: Vec<u8>,
         /// `block_height` is the height of the conflicting blocks
         block_height: u64,
         /// `pub_rand is` the public randomness the finality provider has committed to.
         /// Deserializes to `SchnorrPubRand`
-        pub_rand: Bytes,
+        pub_rand: Vec<u8>,
         /// `canonical_app_hash` is the AppHash of the canonical block
-        canonical_app_hash: Bytes,
+        canonical_app_hash: Vec<u8>,
         /// `fork_app_hash` is the AppHash of the fork block
         fork_app_hash: Bytes,
         /// `canonical_finality_sig` is the finality signature to the canonical block,
@@ -43,17 +43,16 @@ pub enum BabylonMsg {
         /// the `s` in a Schnorr signature `(r, s)`.
         /// `r` is the public randomness already committed by the finality provider.
         /// Deserializes to `SchnorrEOTSSig`
-        canonical_finality_sig: Bytes,
+        canonical_finality_sig: Vec<u8>,
         /// `fork_finality_sig` is the finality signature to the fork block,
         /// where finality signature is an EOTS signature.
         /// Deserializes to `SchnorrEOTSSig`
-        fork_finality_sig: Bytes,
+        fork_finality_sig: Vec<u8>,
     },
 }
 
 pub type BabylonSudoMsg = Empty;
 pub type BabylonQuery = Empty;
-pub type Bytes = Vec<u8>;
 
 // make BabylonMsg to implement CosmosMsg::CustomMsg
 impl cosmwasm_std::CustomMsg for BabylonMsg {}

--- a/packages/bindings/src/msg.rs
+++ b/packages/bindings/src/msg.rs
@@ -37,7 +37,7 @@ pub enum BabylonMsg {
         /// `canonical_app_hash` is the AppHash of the canonical block
         canonical_app_hash: Vec<u8>,
         /// `fork_app_hash` is the AppHash of the fork block
-        fork_app_hash: Bytes,
+        fork_app_hash: Vec<u8>,
         /// `canonical_finality_sig` is the finality signature to the canonical block,
         /// where finality signature is an EOTS signature, i.e.,
         /// the `s` in a Schnorr signature `(r, s)`.


### PR DESCRIPTION
## Summary

This is a follow-on PR from https://github.com/babylonlabs-io/babylon-contract/pull/92 (implement slashing for op stack consumer chains)

It updates the `EquivocationEvidence` msg to match the latest Babylon update

## Test plan

```bash
# build the contract
cargo build
cargo optimize

# test it
cargo test
cargo integration
```