### PR TITLE
F/rewards claiming babylon

### DIFF
--- a/contracts/babylon/benches/main.rs
+++ b/contracts/babylon/benches/main.rs
@@ -54,7 +54,7 @@ pub fn setup_instance() -> Instance<MockApi, MockStorage, MockQuerier> {
         btc_finality_code_id: None,
         btc_finality_msg: None,
         admin: None,
-        ics20_info: None,
+        ics20_channel_id: None,
     };
     let info = mock_info(CREATOR, &[]);
     let res: Response = instantiate(&mut deps, mock_env(), info, msg).unwrap();

--- a/contracts/babylon/benches/main.rs
+++ b/contracts/babylon/benches/main.rs
@@ -54,7 +54,7 @@ pub fn setup_instance() -> Instance<MockApi, MockStorage, MockQuerier> {
         btc_finality_code_id: None,
         btc_finality_msg: None,
         admin: None,
-        transfer_info: None,
+        ics20_info: None,
     };
     let info = mock_info(CREATOR, &[]);
     let res: Response = instantiate(&mut deps, mock_env(), info, msg).unwrap();

--- a/contracts/babylon/schema/babylon-contract.json
+++ b/contracts/babylon/schema/babylon-contract.json
@@ -171,29 +171,6 @@
           }
         },
         "additionalProperties": false
-      },
-      {
-        "description": "`SendRewards` is a message sent by the staking contract, to send rewards to the Babylon chain",
-        "type": "object",
-        "required": [
-          "send_rewards"
-        ],
-        "properties": {
-          "send_rewards": {
-            "type": "object",
-            "required": [
-              "to_address"
-            ],
-            "properties": {
-              "to_address": {
-                "description": "`to_address` is the address on the Babylon chain to send the rewards to",
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
       }
     ],
     "definitions": {

--- a/contracts/babylon/schema/babylon-contract.json
+++ b/contracts/babylon/schema/babylon-contract.json
@@ -89,23 +89,19 @@
           "null"
         ]
       },
+      "ics20_channel_id": {
+        "description": "IBC information for ICS-020 rewards transfer. If not set, distributed rewards will be native to the Consumer",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
       "network": {
         "$ref": "#/definitions/Network"
       },
       "notify_cosmos_zone": {
         "description": "notify_cosmos_zone indicates whether to send Cosmos zone messages notifying BTC-finalised headers. NOTE: If set to true, then the Cosmos zone needs to integrate the corresponding message handler as well",
         "type": "boolean"
-      },
-      "transfer_info": {
-        "description": "IBC information for ICS-020 rewards transfer. If not set, distributed rewards will be native to the Consumer",
-        "anyOf": [
-          {
-            "$ref": "#/definitions/IbcTransferInfo"
-          },
-          {
-            "type": "null"
-          }
-        ]
       }
     },
     "additionalProperties": false,
@@ -114,22 +110,6 @@
         "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
         "type": "string"
       },
-      "IbcTransferInfo": {
-        "type": "object",
-        "required": [
-          "channel_id",
-          "recipient"
-        ],
-        "properties": {
-          "channel_id": {
-            "type": "string"
-          },
-          "recipient": {
-            "$ref": "#/definitions/Recipient"
-          }
-        },
-        "additionalProperties": false
-      },
       "Network": {
         "type": "string",
         "enum": [
@@ -137,34 +117,6 @@
           "testnet",
           "signet",
           "regtest"
-        ]
-      },
-      "Recipient": {
-        "oneOf": [
-          {
-            "type": "object",
-            "required": [
-              "contract_addr"
-            ],
-            "properties": {
-              "contract_addr": {
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "module_addr"
-            ],
-            "properties": {
-              "module_addr": {
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          }
         ]
       }
     }
@@ -221,7 +173,7 @@
         "additionalProperties": false
       },
       {
-        "description": "`SendRewards` is a message sent by the finality contract, to send rewards to Babylon",
+        "description": "`SendRewards` is a message sent by the staking contract, to send rewards to the Babylon chain",
         "type": "object",
         "required": [
           "send_rewards"
@@ -230,15 +182,12 @@
           "send_rewards": {
             "type": "object",
             "required": [
-              "fp_distribution"
+              "to_address"
             ],
             "properties": {
-              "fp_distribution": {
-                "description": "`fp_distribution` is the list of finality providers and their rewards",
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/RewardInfo"
-                }
+              "to_address": {
+                "description": "`to_address` is the address on the Babylon chain to send the rewards to",
+                "type": "string"
               }
             },
             "additionalProperties": false
@@ -368,26 +317,6 @@
           }
         },
         "additionalProperties": false
-      },
-      "RewardInfo": {
-        "type": "object",
-        "required": [
-          "fp_pubkey_hex",
-          "reward"
-        ],
-        "properties": {
-          "fp_pubkey_hex": {
-            "type": "string"
-          },
-          "reward": {
-            "$ref": "#/definitions/Uint128"
-          }
-        },
-        "additionalProperties": false
-      },
-      "Uint128": {
-        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
-        "type": "string"
       }
     }
   },
@@ -636,7 +565,7 @@
         "additionalProperties": false
       },
       {
-        "description": "TransferInfo returns the IBC transfer information stored in the contract for ICS-020 rewards transfer. If not set, distributed rewards are native to the Consumer",
+        "description": "TransferInfo returns the IBC transfer information stored in the contract for ICS-020 rewards transfer.",
         "type": "object",
         "required": [
           "transfer_info"
@@ -1644,38 +1573,11 @@
     },
     "transfer_info": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "title": "Nullable_TransferInfo",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/TransferInfo"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "definitions": {
-        "TransferInfo": {
-          "description": "IBC transfer (ICS-020) channel settings",
-          "type": "object",
-          "required": [
-            "address_type",
-            "channel_id",
-            "to_address"
-          ],
-          "properties": {
-            "address_type": {
-              "type": "string"
-            },
-            "channel_id": {
-              "type": "string"
-            },
-            "to_address": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        }
-      }
+      "title": "Nullable_String",
+      "type": [
+        "string",
+        "null"
+      ]
     }
   }
 }

--- a/contracts/babylon/schema/raw/execute.json
+++ b/contracts/babylon/schema/raw/execute.json
@@ -50,7 +50,7 @@
       "additionalProperties": false
     },
     {
-      "description": "`SendRewards` is a message sent by the finality contract, to send rewards to Babylon",
+      "description": "`SendRewards` is a message sent by the staking contract, to send rewards to the Babylon chain",
       "type": "object",
       "required": [
         "send_rewards"
@@ -59,15 +59,12 @@
         "send_rewards": {
           "type": "object",
           "required": [
-            "fp_distribution"
+            "to_address"
           ],
           "properties": {
-            "fp_distribution": {
-              "description": "`fp_distribution` is the list of finality providers and their rewards",
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/RewardInfo"
-              }
+            "to_address": {
+              "description": "`to_address` is the address on the Babylon chain to send the rewards to",
+              "type": "string"
             }
           },
           "additionalProperties": false
@@ -197,26 +194,6 @@
         }
       },
       "additionalProperties": false
-    },
-    "RewardInfo": {
-      "type": "object",
-      "required": [
-        "fp_pubkey_hex",
-        "reward"
-      ],
-      "properties": {
-        "fp_pubkey_hex": {
-          "type": "string"
-        },
-        "reward": {
-          "$ref": "#/definitions/Uint128"
-        }
-      },
-      "additionalProperties": false
-    },
-    "Uint128": {
-      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
-      "type": "string"
     }
   }
 }

--- a/contracts/babylon/schema/raw/execute.json
+++ b/contracts/babylon/schema/raw/execute.json
@@ -48,29 +48,6 @@
         }
       },
       "additionalProperties": false
-    },
-    {
-      "description": "`SendRewards` is a message sent by the staking contract, to send rewards to the Babylon chain",
-      "type": "object",
-      "required": [
-        "send_rewards"
-      ],
-      "properties": {
-        "send_rewards": {
-          "type": "object",
-          "required": [
-            "to_address"
-          ],
-          "properties": {
-            "to_address": {
-              "description": "`to_address` is the address on the Babylon chain to send the rewards to",
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/contracts/babylon/schema/raw/instantiate.json
+++ b/contracts/babylon/schema/raw/instantiate.json
@@ -85,23 +85,19 @@
         "null"
       ]
     },
+    "ics20_channel_id": {
+      "description": "IBC information for ICS-020 rewards transfer. If not set, distributed rewards will be native to the Consumer",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "network": {
       "$ref": "#/definitions/Network"
     },
     "notify_cosmos_zone": {
       "description": "notify_cosmos_zone indicates whether to send Cosmos zone messages notifying BTC-finalised headers. NOTE: If set to true, then the Cosmos zone needs to integrate the corresponding message handler as well",
       "type": "boolean"
-    },
-    "transfer_info": {
-      "description": "IBC information for ICS-020 rewards transfer. If not set, distributed rewards will be native to the Consumer",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/IbcTransferInfo"
-        },
-        {
-          "type": "null"
-        }
-      ]
     }
   },
   "additionalProperties": false,
@@ -110,22 +106,6 @@
       "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
       "type": "string"
     },
-    "IbcTransferInfo": {
-      "type": "object",
-      "required": [
-        "channel_id",
-        "recipient"
-      ],
-      "properties": {
-        "channel_id": {
-          "type": "string"
-        },
-        "recipient": {
-          "$ref": "#/definitions/Recipient"
-        }
-      },
-      "additionalProperties": false
-    },
     "Network": {
       "type": "string",
       "enum": [
@@ -133,34 +113,6 @@
         "testnet",
         "signet",
         "regtest"
-      ]
-    },
-    "Recipient": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "contract_addr"
-          ],
-          "properties": {
-            "contract_addr": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "module_addr"
-          ],
-          "properties": {
-            "module_addr": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        }
       ]
     }
   }

--- a/contracts/babylon/schema/raw/query.json
+++ b/contracts/babylon/schema/raw/query.json
@@ -243,7 +243,7 @@
       "additionalProperties": false
     },
     {
-      "description": "TransferInfo returns the IBC transfer information stored in the contract for ICS-020 rewards transfer. If not set, distributed rewards are native to the Consumer",
+      "description": "TransferInfo returns the IBC transfer information stored in the contract for ICS-020 rewards transfer.",
       "type": "object",
       "required": [
         "transfer_info"

--- a/contracts/babylon/schema/raw/response_to_transfer_info.json
+++ b/contracts/babylon/schema/raw/response_to_transfer_info.json
@@ -1,35 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Nullable_TransferInfo",
-  "anyOf": [
-    {
-      "$ref": "#/definitions/TransferInfo"
-    },
-    {
-      "type": "null"
-    }
-  ],
-  "definitions": {
-    "TransferInfo": {
-      "description": "IBC transfer (ICS-020) channel settings",
-      "type": "object",
-      "required": [
-        "address_type",
-        "channel_id",
-        "to_address"
-      ],
-      "properties": {
-        "address_type": {
-          "type": "string"
-        },
-        "channel_id": {
-          "type": "string"
-        },
-        "to_address": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false
-    }
-  }
+  "title": "Nullable_String",
+  "type": [
+    "string",
+    "null"
+  ]
 }

--- a/contracts/babylon/src/contract.rs
+++ b/contracts/babylon/src/contract.rs
@@ -97,7 +97,7 @@ pub fn instantiate(
     CONFIG.save(deps.storage, &cfg)?;
 
     // Save the IBC transfer info
-    if let Some(transfer_info) = msg.ics20_info {
+    if let Some(transfer_info) = msg.ics20_channel_id {
         IBC_TRANSFER.save(deps.storage, &transfer_info)?;
     }
 
@@ -302,10 +302,10 @@ pub fn execute(
             // Route to babylon over IBC, if available
             let transfer_info = IBC_TRANSFER.may_load(deps.storage)?;
             match transfer_info {
-                Some(transfer_info) => {
+                Some(ics20_channel_id) => {
                     // Construct the transfer message
                     let ibc_msg = IbcMsg::Transfer {
-                        channel_id: transfer_info.channel_id,
+                        channel_id: ics20_channel_id,
                         to_address,
                         amount: info.funds[0].clone(),
                         timeout: packet_timeout(&env),
@@ -364,7 +364,7 @@ mod tests {
             admin: None,
             consumer_name: None,
             consumer_description: None,
-            ics20_info: None,
+            ics20_channel_id: None,
         };
         let info = message_info(&deps.api.addr_make(CREATOR), &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -387,7 +387,7 @@ mod tests {
             admin: None,
             consumer_name: None,
             consumer_description: None,
-            ics20_info: None,
+            ics20_channel_id: None,
         };
         let info = message_info(&deps.api.addr_make(CREATOR), &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -423,7 +423,7 @@ mod tests {
             admin: None,
             consumer_name: None,
             consumer_description: None,
-            ics20_info: None,
+            ics20_channel_id: None,
         };
         let info = message_info(&deps.api.addr_make(CREATOR), &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();

--- a/contracts/babylon/src/contract.rs
+++ b/contracts/babylon/src/contract.rs
@@ -97,7 +97,7 @@ pub fn instantiate(
     CONFIG.save(deps.storage, &cfg)?;
 
     // Save the IBC transfer info
-    if let Some(transfer_info) = msg.transfer_info {
+    if let Some(transfer_info) = msg.ics20_info {
         IBC_TRANSFER.save(deps.storage, &transfer_info)?;
     }
 
@@ -368,7 +368,7 @@ mod tests {
             admin: None,
             consumer_name: None,
             consumer_description: None,
-            transfer_info: None,
+            ics20_info: None,
         };
         let info = message_info(&deps.api.addr_make(CREATOR), &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -391,7 +391,7 @@ mod tests {
             admin: None,
             consumer_name: None,
             consumer_description: None,
-            transfer_info: None,
+            ics20_info: None,
         };
         let info = message_info(&deps.api.addr_make(CREATOR), &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -427,7 +427,7 @@ mod tests {
             admin: None,
             consumer_name: None,
             consumer_description: None,
-            transfer_info: None,
+            ics20_info: None,
         };
         let info = message_info(&deps.api.addr_make(CREATOR), &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();

--- a/contracts/babylon/src/ibc.rs
+++ b/contracts/babylon/src/ibc.rs
@@ -3,8 +3,8 @@ use babylon_bindings::BabylonMsg;
 use babylon_proto::babylon::zoneconcierge::v1::{
     zoneconcierge_packet_data::Packet, BtcTimestamp, ZoneconciergePacketData,
 };
-use cosmwasm_schema::cw_serde;
 
+use crate::msg::ibc::IbcIcs20Info;
 use crate::state::config::CONFIG;
 use cosmwasm_std::{
     Binary, DepsMut, Env, Event, Ibc3ChannelOpenResponse, IbcBasicResponse, IbcChannel,
@@ -21,13 +21,7 @@ pub const IBC_ORDERING: IbcOrder = IbcOrder::Ordered;
 pub const IBC_CHANNEL: Item<IbcChannel> = Item::new("ibc_channel");
 
 /// IBC transfer (ICS-020) channel settings
-#[cw_serde]
-pub struct TransferInfo {
-    pub channel_id: String,
-    pub to_address: String,
-    pub address_type: String,
-}
-pub const IBC_TRANSFER: Item<TransferInfo> = Item::new("ibc_transfer");
+pub const IBC_TRANSFER: Item<IbcIcs20Info> = Item::new("ibc_transfer");
 
 /// This is executed during the ChannelOpenInit and ChannelOpenTry
 /// of the IBC 4-step channel protocol
@@ -324,7 +318,7 @@ mod tests {
     use super::*;
     use crate::contract::instantiate;
     use crate::msg::contract::InstantiateMsg;
-    use crate::msg::ibc::{IbcIcs20Info, Recipient};
+    use crate::msg::ibc::IbcIcs20Info;
     use cosmwasm_std::testing::message_info;
     use cosmwasm_std::testing::{
         mock_dependencies, mock_env, mock_ibc_channel_open_try, MockApi, MockQuerier, MockStorage,
@@ -350,7 +344,7 @@ mod tests {
             consumer_description: None,
             transfer_info: Some(IbcIcs20Info {
                 channel_id: "channel-1".to_string(),
-                recipient: Recipient::ModuleAddr("zoneconcierge".to_string()),
+                to_address: "bbn1wdptld6nw2plxzf0w62gqc60tlw5kypzej89y3".to_string(),
             }),
         };
         let info = message_info(&deps.api.addr_make(CREATOR), &[]);

--- a/contracts/babylon/src/ibc.rs
+++ b/contracts/babylon/src/ibc.rs
@@ -342,7 +342,7 @@ mod tests {
             admin: None,
             consumer_name: None,
             consumer_description: None,
-            transfer_info: Some(IbcIcs20Info {
+            ics20_info: Some(IbcIcs20Info {
                 channel_id: "channel-1".to_string(),
                 to_address: "bbn1wdptld6nw2plxzf0w62gqc60tlw5kypzej89y3".to_string(),
             }),

--- a/contracts/babylon/src/ibc.rs
+++ b/contracts/babylon/src/ibc.rs
@@ -4,7 +4,6 @@ use babylon_proto::babylon::zoneconcierge::v1::{
     zoneconcierge_packet_data::Packet, BtcTimestamp, ZoneconciergePacketData,
 };
 
-use crate::msg::ibc::IbcIcs20Info;
 use crate::state::config::CONFIG;
 use cosmwasm_std::{
     Binary, DepsMut, Env, Event, Ibc3ChannelOpenResponse, IbcBasicResponse, IbcChannel,
@@ -21,7 +20,7 @@ pub const IBC_ORDERING: IbcOrder = IbcOrder::Ordered;
 pub const IBC_CHANNEL: Item<IbcChannel> = Item::new("ibc_channel");
 
 /// IBC transfer (ICS-020) channel settings
-pub const IBC_TRANSFER: Item<IbcIcs20Info> = Item::new("ibc_transfer");
+pub const IBC_TRANSFER: Item<String> = Item::new("ibc_ics20");
 
 /// This is executed during the ChannelOpenInit and ChannelOpenTry
 /// of the IBC 4-step channel protocol
@@ -318,7 +317,6 @@ mod tests {
     use super::*;
     use crate::contract::instantiate;
     use crate::msg::contract::InstantiateMsg;
-    use crate::msg::ibc::IbcIcs20Info;
     use cosmwasm_std::testing::message_info;
     use cosmwasm_std::testing::{
         mock_dependencies, mock_env, mock_ibc_channel_open_try, MockApi, MockQuerier, MockStorage,
@@ -342,10 +340,7 @@ mod tests {
             admin: None,
             consumer_name: None,
             consumer_description: None,
-            ics20_info: Some(IbcIcs20Info {
-                channel_id: "channel-1".to_string(),
-                to_address: "bbn1wdptld6nw2plxzf0w62gqc60tlw5kypzej89y3".to_string(),
-            }),
+            ics20_channel_id: Some("channel-1".to_string()),
         };
         let info = message_info(&deps.api.addr_make(CREATOR), &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();

--- a/contracts/babylon/src/ibc.rs
+++ b/contracts/babylon/src/ibc.rs
@@ -324,7 +324,7 @@ mod tests {
     use super::*;
     use crate::contract::instantiate;
     use crate::msg::contract::InstantiateMsg;
-    use crate::msg::ibc::{IbcTransferInfo, Recipient};
+    use crate::msg::ibc::{IbcIcs20Info, Recipient};
     use cosmwasm_std::testing::message_info;
     use cosmwasm_std::testing::{
         mock_dependencies, mock_env, mock_ibc_channel_open_try, MockApi, MockQuerier, MockStorage,
@@ -348,7 +348,7 @@ mod tests {
             admin: None,
             consumer_name: None,
             consumer_description: None,
-            transfer_info: Some(IbcTransferInfo {
+            transfer_info: Some(IbcIcs20Info {
                 channel_id: "channel-1".to_string(),
                 recipient: Recipient::ModuleAddr("zoneconcierge".to_string()),
             }),

--- a/contracts/babylon/src/msg/contract.rs
+++ b/contracts/babylon/src/msg/contract.rs
@@ -55,7 +55,7 @@ pub struct InstantiateMsg {
     pub consumer_description: Option<String>,
     /// IBC information for ICS-020 rewards transfer.
     /// If not set, distributed rewards will be native to the Consumer
-    pub transfer_info: Option<crate::msg::ibc::IbcTransferInfo>,
+    pub transfer_info: Option<crate::msg::ibc::IbcIcs20Info>,
 }
 
 impl ContractMsg for InstantiateMsg {

--- a/contracts/babylon/src/msg/contract.rs
+++ b/contracts/babylon/src/msg/contract.rs
@@ -55,7 +55,7 @@ pub struct InstantiateMsg {
     pub consumer_description: Option<String>,
     /// IBC information for ICS-020 rewards transfer.
     /// If not set, distributed rewards will be native to the Consumer
-    pub transfer_info: Option<crate::msg::ibc::IbcIcs20Info>,
+    pub ics20_info: Option<crate::msg::ibc::IbcIcs20Info>,
 }
 
 impl ContractMsg for InstantiateMsg {
@@ -87,7 +87,7 @@ impl ContractMsg for InstantiateMsg {
             }
         }
 
-        if let Some(transfer_info) = &self.transfer_info {
+        if let Some(transfer_info) = &self.ics20_info {
             transfer_info.validate()?;
         }
 

--- a/contracts/babylon/src/msg/contract.rs
+++ b/contracts/babylon/src/msg/contract.rs
@@ -54,7 +54,7 @@ pub struct InstantiateMsg {
     pub consumer_description: Option<String>,
     /// IBC information for ICS-020 rewards transfer.
     /// If not set, distributed rewards will be native to the Consumer
-    pub ics20_info: Option<crate::msg::ibc::IbcIcs20Info>,
+    pub ics20_channel_id: Option<String>,
 }
 
 impl ContractMsg for InstantiateMsg {
@@ -86,8 +86,10 @@ impl ContractMsg for InstantiateMsg {
             }
         }
 
-        if let Some(transfer_info) = &self.ics20_info {
-            transfer_info.validate()?;
+        if let Some(channel_id) = &self.ics20_channel_id {
+            if channel_id.trim().is_empty() {
+                return Err(StdError::generic_err("ICS-020 channel_id cannot be empty"));
+            }
         }
 
         Ok(())
@@ -172,7 +174,6 @@ pub enum QueryMsg {
     CzHeader { height: u64 },
     /// TransferInfo returns the IBC transfer information stored in the contract
     /// for ICS-020 rewards transfer.
-    /// If not set, distributed rewards are native to the Consumer
-    #[returns(crate::msg::ibc::TransferInfoResponse)]
+    #[returns(Option<String>)]
     TransferInfo {},
 }

--- a/contracts/babylon/src/msg/contract.rs
+++ b/contracts/babylon/src/msg/contract.rs
@@ -4,7 +4,6 @@ use cosmwasm_std::{Binary, StdError, StdResult};
 use babylon_apis::finality_api::Evidence;
 
 use crate::msg::btc_header::BtcHeader;
-use babylon_apis::btc_staking_api::RewardInfo;
 #[cfg(not(target_arch = "wasm32"))]
 use {
     crate::msg::btc_header::{BtcHeaderResponse, BtcHeadersResponse},
@@ -116,10 +115,11 @@ pub enum ExecuteMsg {
     /// This will be forwarded over IBC to the Babylon side for propagation to other Consumers, and
     /// Babylon itself
     Slashing { evidence: Evidence },
-    /// `SendRewards` is a message sent by the finality contract, to send rewards to Babylon
+    /// `SendRewards` is a message sent by the staking contract, to send rewards to the Babylon
+    /// chain
     SendRewards {
-        /// `fp_distribution` is the list of finality providers and their rewards
-        fp_distribution: Vec<RewardInfo>,
+        /// `to_address` is the address on the Babylon chain to send the rewards to
+        to_address: String,
     },
 }
 

--- a/contracts/babylon/src/msg/contract.rs
+++ b/contracts/babylon/src/msg/contract.rs
@@ -117,12 +117,6 @@ pub enum ExecuteMsg {
     /// This will be forwarded over IBC to the Babylon side for propagation to other Consumers, and
     /// Babylon itself
     Slashing { evidence: Evidence },
-    /// `SendRewards` is a message sent by the staking contract, to send rewards to the Babylon
-    /// chain
-    SendRewards {
-        /// `to_address` is the address on the Babylon chain to send the rewards to
-        to_address: String,
-    },
 }
 
 #[cw_serde]

--- a/contracts/babylon/src/msg/ibc.rs
+++ b/contracts/babylon/src/msg/ibc.rs
@@ -5,7 +5,7 @@ use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{StdError, StdResult};
 
 #[cw_serde]
-pub struct IbcTransferInfo {
+pub struct IbcIcs20Info {
     pub channel_id: String,
     pub recipient: Recipient,
 }
@@ -16,7 +16,7 @@ pub enum Recipient {
     ModuleAddr(String),
 }
 
-impl IbcTransferInfo {
+impl IbcIcs20Info {
     pub fn validate(&self) -> StdResult<()> {
         if self.channel_id.is_empty() {
             return Err(StdError::generic_err("Empty IBC channel id"));

--- a/contracts/babylon/src/msg/ibc.rs
+++ b/contracts/babylon/src/msg/ibc.rs
@@ -1,26 +1,8 @@
-use babylon_apis::to_canonical_addr;
 use cosmos_sdk_proto::ibc::core::channel::v1::{acknowledgement::Response, Acknowledgement};
+
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{StdError, StdResult};
 
-#[cw_serde]
-pub struct IbcIcs20Info {
-    pub channel_id: String,
-    pub to_address: String,
-}
-
-impl IbcIcs20Info {
-    pub fn validate(&self) -> StdResult<()> {
-        if self.channel_id.is_empty() {
-            return Err(StdError::generic_err("Empty IBC channel id"));
-        }
-        to_canonical_addr(&self.to_address, "bbn")
-            .map_err(|e| StdError::generic_err(format!("Invalid recipient address: {}", e)))?;
-        Ok(())
-    }
-}
-
-pub type TransferInfoResponse = Option<IbcIcs20Info>;
+pub type TransferInfoResponse = Option<String>;
 
 pub fn new_ack_res() -> Acknowledgement {
     let resp = Response::Result(vec![]);

--- a/contracts/babylon/src/msg/ibc.rs
+++ b/contracts/babylon/src/msg/ibc.rs
@@ -1,4 +1,3 @@
-use crate::ibc::TransferInfo;
 use babylon_apis::to_canonical_addr;
 use cosmos_sdk_proto::ibc::core::channel::v1::{acknowledgement::Response, Acknowledgement};
 use cosmwasm_schema::cw_serde;
@@ -7,13 +6,7 @@ use cosmwasm_std::{StdError, StdResult};
 #[cw_serde]
 pub struct IbcIcs20Info {
     pub channel_id: String,
-    pub recipient: Recipient,
-}
-
-#[cw_serde]
-pub enum Recipient {
-    ContractAddr(String),
-    ModuleAddr(String),
+    pub to_address: String,
 }
 
 impl IbcIcs20Info {
@@ -21,23 +14,13 @@ impl IbcIcs20Info {
         if self.channel_id.is_empty() {
             return Err(StdError::generic_err("Empty IBC channel id"));
         }
-        match self.recipient {
-            Recipient::ContractAddr(ref addr) => {
-                to_canonical_addr(addr, "bbn").map_err(|e| {
-                    StdError::generic_err(format!("Invalid contract address: {}", e))
-                })?;
-            }
-            Recipient::ModuleAddr(ref addr) => {
-                if addr.is_empty() {
-                    return Err(StdError::generic_err("Empty module address"));
-                }
-            }
-        }
+        to_canonical_addr(&self.to_address, "bbn")
+            .map_err(|e| StdError::generic_err(format!("Invalid recipient address: {}", e)))?;
         Ok(())
     }
 }
 
-pub type TransferInfoResponse = Option<TransferInfo>;
+pub type TransferInfoResponse = Option<IbcIcs20Info>;
 
 pub fn new_ack_res() -> Acknowledgement {
     let resp = Response::Result(vec![]);

--- a/contracts/babylon/src/multitest.rs
+++ b/contracts/babylon/src/multitest.rs
@@ -37,8 +37,6 @@ fn initialization() {
 
 mod instantiation {
     use super::*;
-    use crate::msg::ibc::Recipient;
-    use babylon_apis::{to_bech32_addr, to_module_canonical_addr};
     use cosmwasm_std::to_json_string;
 
     #[test]
@@ -103,33 +101,9 @@ mod instantiation {
     }
 
     #[test]
-    fn instantiate_ibc_transfer_module_addr_works() {
+    fn instantiate_ibc_ics20_works() {
         let suite = SuiteBuilder::new()
-            .with_ibc_transfer_info(
-                "channel-10",
-                Recipient::ModuleAddr("module-addr".to_string()),
-            )
-            .build();
-
-        // Confirm the transfer info has been set
-        let transfer_info = suite.get_transfer_info().unwrap();
-        assert_eq!(transfer_info.channel_id, "channel-10");
-        assert_eq!(
-            transfer_info.to_address,
-            to_bech32_addr("bbn", &to_module_canonical_addr("module-addr"))
-                .unwrap()
-                .to_string()
-        );
-        assert_eq!(transfer_info.address_type, "module");
-    }
-
-    #[test]
-    fn instantiate_ibc_transfer_contract_addr_works() {
-        let suite = SuiteBuilder::new()
-            .with_ibc_transfer_info(
-                "channel-10",
-                Recipient::ContractAddr("bbn1wdptld6nw2plxzf0w62gqc60tlw5kypzej89y3".to_string()),
-            )
+            .with_ics20_info("channel-10", "bbn1wdptld6nw2plxzf0w62gqc60tlw5kypzej89y3")
             .build();
 
         // Confirm the transfer info has been set
@@ -139,7 +113,6 @@ mod instantiation {
             transfer_info.to_address,
             "bbn1wdptld6nw2plxzf0w62gqc60tlw5kypzej89y3".to_string()
         );
-        assert_eq!(transfer_info.address_type, "contract");
     }
 }
 

--- a/contracts/babylon/src/multitest.rs
+++ b/contracts/babylon/src/multitest.rs
@@ -102,17 +102,11 @@ mod instantiation {
 
     #[test]
     fn instantiate_ibc_ics20_works() {
-        let suite = SuiteBuilder::new()
-            .with_ics20_info("channel-10", "bbn1wdptld6nw2plxzf0w62gqc60tlw5kypzej89y3")
-            .build();
+        let suite = SuiteBuilder::new().with_ics20_channel("channel-10").build();
 
         // Confirm the transfer info has been set
-        let transfer_info = suite.get_transfer_info().unwrap();
-        assert_eq!(transfer_info.channel_id, "channel-10");
-        assert_eq!(
-            transfer_info.to_address,
-            "bbn1wdptld6nw2plxzf0w62gqc60tlw5kypzej89y3".to_string()
-        );
+        let channel_id = suite.get_transfer_info().unwrap();
+        assert_eq!(channel_id, "channel-10");
     }
 }
 

--- a/contracts/babylon/src/multitest/suite.rs
+++ b/contracts/babylon/src/multitest/suite.rs
@@ -115,7 +115,7 @@ impl SuiteBuilder {
                     admin: Some(owner.to_string()),
                     consumer_name: Some("TestConsumer".to_string()),
                     consumer_description: Some("Test Consumer Description".to_string()),
-                    transfer_info: self.transfer_info,
+                    ics20_info: self.transfer_info,
                 },
                 &[],
                 "babylon",

--- a/contracts/babylon/src/multitest/suite.rs
+++ b/contracts/babylon/src/multitest/suite.rs
@@ -1,14 +1,13 @@
+use crate::msg::ibc::IbcIcs20Info;
 use crate::msg::ibc::TransferInfoResponse;
-use crate::msg::ibc::{IbcIcs20Info, Recipient};
 use anyhow::Result as AnyResult;
 use derivative::Derivative;
-
-use cosmwasm_std::{Addr, Binary, Empty};
-use cw_multi_test::{AppResponse, Contract, ContractWrapper, Executor};
 
 use babylon_bindings::BabylonMsg;
 use babylon_bindings_test::BabylonApp;
 use babylon_bitcoin::chain_params::Network;
+use cosmwasm_std::{Addr, Binary, Empty};
+use cw_multi_test::{AppResponse, Contract, ContractWrapper, Executor};
 
 use crate::msg::contract::{InstantiateMsg, QueryMsg};
 use crate::multitest::{CONTRACT1_ADDR, CONTRACT2_ADDR};
@@ -69,11 +68,10 @@ impl SuiteBuilder {
     }
 
     /// Sets the IBC transfer info
-    #[allow(dead_code)]
-    pub fn with_ibc_transfer_info(mut self, channel_id: &str, recipient: Recipient) -> Self {
+    pub fn with_ics20_info(mut self, channel_id: &str, recipient: &str) -> Self {
         let transfer_info = IbcIcs20Info {
             channel_id: channel_id.into(),
-            recipient,
+            to_address: recipient.to_string(),
         };
         self.transfer_info = Some(transfer_info);
         self

--- a/contracts/babylon/src/multitest/suite.rs
+++ b/contracts/babylon/src/multitest/suite.rs
@@ -1,4 +1,3 @@
-use crate::msg::ibc::IbcIcs20Info;
 use crate::msg::ibc::TransferInfoResponse;
 use anyhow::Result as AnyResult;
 use derivative::Derivative;
@@ -44,7 +43,7 @@ pub struct SuiteBuilder {
     funds: Vec<(Addr, u128)>,
     staking_msg: Option<String>,
     finality_msg: Option<String>,
-    transfer_info: Option<IbcIcs20Info>,
+    ics20_channel_id: Option<String>,
 }
 
 impl SuiteBuilder {
@@ -68,12 +67,8 @@ impl SuiteBuilder {
     }
 
     /// Sets the IBC transfer info
-    pub fn with_ics20_info(mut self, channel_id: &str, recipient: &str) -> Self {
-        let transfer_info = IbcIcs20Info {
-            channel_id: channel_id.into(),
-            to_address: recipient.to_string(),
-        };
-        self.transfer_info = Some(transfer_info);
+    pub fn with_ics20_channel(mut self, channel_id: &str) -> Self {
+        self.ics20_channel_id = Some(channel_id.to_owned());
         self
     }
 
@@ -115,7 +110,7 @@ impl SuiteBuilder {
                     admin: Some(owner.to_string()),
                     consumer_name: Some("TestConsumer".to_string()),
                     consumer_description: Some("Test Consumer Description".to_string()),
-                    ics20_info: self.transfer_info,
+                    ics20_channel_id: self.ics20_channel_id,
                 },
                 &[],
                 "babylon",

--- a/contracts/babylon/src/multitest/suite.rs
+++ b/contracts/babylon/src/multitest/suite.rs
@@ -1,5 +1,5 @@
 use crate::msg::ibc::TransferInfoResponse;
-use crate::msg::ibc::{IbcTransferInfo, Recipient};
+use crate::msg::ibc::{IbcIcs20Info, Recipient};
 use anyhow::Result as AnyResult;
 use derivative::Derivative;
 
@@ -45,7 +45,7 @@ pub struct SuiteBuilder {
     funds: Vec<(Addr, u128)>,
     staking_msg: Option<String>,
     finality_msg: Option<String>,
-    transfer_info: Option<IbcTransferInfo>,
+    transfer_info: Option<IbcIcs20Info>,
 }
 
 impl SuiteBuilder {
@@ -71,7 +71,7 @@ impl SuiteBuilder {
     /// Sets the IBC transfer info
     #[allow(dead_code)]
     pub fn with_ibc_transfer_info(mut self, channel_id: &str, recipient: Recipient) -> Self {
-        let transfer_info = IbcTransferInfo {
+        let transfer_info = IbcIcs20Info {
             channel_id: channel_id.into(),
             recipient,
         };

--- a/contracts/babylon/src/state/btc_light_client.rs
+++ b/contracts/babylon/src/state/btc_light_client.rs
@@ -372,7 +372,6 @@ pub(crate) mod tests {
         match resp {
             ExecuteMsg::BtcHeaders { headers } => headers,
             ExecuteMsg::Slashing { .. } => unreachable!("unexpected slashing message"),
-            ExecuteMsg::SendRewards { .. } => unreachable!("unexpected send rewards message"),
         }
     }
 

--- a/contracts/babylon/tests/integration.rs
+++ b/contracts/babylon/tests/integration.rs
@@ -77,7 +77,6 @@ fn get_fork_msg_test_headers() -> Vec<BtcHeader> {
     match resp {
         ExecuteMsg::BtcHeaders { headers } => headers,
         ExecuteMsg::Slashing { .. } => unreachable!("unexpected slashing message"),
-        ExecuteMsg::SendRewards { .. } => unreachable!("unexpected send rewards message"),
     }
 }
 

--- a/contracts/babylon/tests/integration.rs
+++ b/contracts/babylon/tests/integration.rs
@@ -52,7 +52,7 @@ fn setup() -> Instance<MockApi, MockStorage, MockQuerier> {
         btc_finality_code_id: None,
         btc_finality_msg: None,
         admin: None,
-        transfer_info: None,
+        ics20_info: None,
     };
     let info = message_info(&Addr::unchecked(CREATOR), &[]);
     let res: Response = instantiate(&mut deps, mock_env(), info, msg).unwrap();
@@ -108,7 +108,7 @@ fn instantiate_works() {
         btc_finality_code_id: None,
         btc_finality_msg: None,
         admin: None,
-        transfer_info: None,
+        ics20_info: None,
     };
     let info = message_info(&Addr::unchecked(CREATOR), &[]);
     let res: ContractResult<Response> = instantiate(&mut deps, mock_env(), info, msg);

--- a/contracts/babylon/tests/integration.rs
+++ b/contracts/babylon/tests/integration.rs
@@ -52,7 +52,7 @@ fn setup() -> Instance<MockApi, MockStorage, MockQuerier> {
         btc_finality_code_id: None,
         btc_finality_msg: None,
         admin: None,
-        ics20_info: None,
+        ics20_channel_id: None,
     };
     let info = message_info(&Addr::unchecked(CREATOR), &[]);
     let res: Response = instantiate(&mut deps, mock_env(), info, msg).unwrap();
@@ -108,7 +108,7 @@ fn instantiate_works() {
         btc_finality_code_id: None,
         btc_finality_msg: None,
         admin: None,
-        ics20_info: None,
+        ics20_channel_id: None,
     };
     let info = message_info(&Addr::unchecked(CREATOR), &[]);
     let res: ContractResult<Response> = instantiate(&mut deps, mock_env(), info, msg);

--- a/contracts/btc-finality/schema/btc-finality.json
+++ b/contracts/btc-finality/schema/btc-finality.json
@@ -232,10 +232,14 @@
       },
       {
 <<<<<<< HEAD
+<<<<<<< HEAD
         "description": "`WithdrawRewards` is a message sent by the Babylon contract on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is the address to claim the rewards.",
 =======
         "description": "`WithdrawRewards` is a message sent by anyone on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is both the address to claim and receive the rewards",
 >>>>>>> 37fca3d (Update schemas)
+=======
+        "description": "`WithdrawRewards` is a message sent by anyone on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is both the address to claim and receive the rewards. It's a Babylon address. If rewards are to be sent to a Consumer address, the staker's equivalent address in that chain will be computed and used.",
+>>>>>>> fbd3b31 (Update schema)
         "type": "object",
         "required": [
           "withdraw_rewards"
@@ -919,7 +923,7 @@
         "additionalProperties": false
       },
       {
-        "description": "`PendingRewards` returns the pending rewards for a user on a finality provider. The rewards are returned in the form of a Coin",
+        "description": "`PendingRewards` returns the pending rewards for a staker on a finality provider. The staker address must be its Babylon delegator address. The rewards are returned in the form of a Coin.",
         "type": "object",
         "required": [
           "pending_rewards"
@@ -929,13 +933,13 @@
             "type": "object",
             "required": [
               "fp_pubkey_hex",
-              "user"
+              "staker_addr"
             ],
             "properties": {
               "fp_pubkey_hex": {
                 "type": "string"
               },
-              "user": {
+              "staker_addr": {
                 "type": "string"
               }
             },
@@ -945,7 +949,7 @@
         "additionalProperties": false
       },
       {
-        "description": "`AllPendingRewards` returns the pending rewards for a user on all finality providers.",
+        "description": "`AllPendingRewards` returns the pending rewards for a staker on all finality providers. The staker address must be its Babylon delegator address.",
         "type": "object",
         "required": [
           "all_pending_rewards"
@@ -954,7 +958,7 @@
           "all_pending_rewards": {
             "type": "object",
             "required": [
-              "user"
+              "staker_addr"
             ],
             "properties": {
               "limit": {
@@ -965,6 +969,9 @@
                 "format": "uint32",
                 "minimum": 0.0
               },
+              "staker_addr": {
+                "type": "string"
+              },
               "start_after": {
                 "anyOf": [
                   {
@@ -974,9 +981,6 @@
                     "type": "null"
                   }
                 ]
-              },
-              "user": {
-                "type": "string"
               }
             },
             "additionalProperties": false

--- a/contracts/btc-finality/schema/btc-finality.json
+++ b/contracts/btc-finality/schema/btc-finality.json
@@ -231,7 +231,11 @@
         "additionalProperties": false
       },
       {
+<<<<<<< HEAD
         "description": "`WithdrawRewards` is a message sent by the Babylon contract on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is the address to claim the rewards.",
+=======
+        "description": "`WithdrawRewards` is a message sent by anyone on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is both the address to claim and receive the rewards",
+>>>>>>> 37fca3d (Update schemas)
         "type": "object",
         "required": [
           "withdraw_rewards"

--- a/contracts/btc-finality/schema/btc-finality.json
+++ b/contracts/btc-finality/schema/btc-finality.json
@@ -231,15 +231,7 @@
         "additionalProperties": false
       },
       {
-<<<<<<< HEAD
-<<<<<<< HEAD
-        "description": "`WithdrawRewards` is a message sent by the Babylon contract on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is the address to claim the rewards.",
-=======
-        "description": "`WithdrawRewards` is a message sent by anyone on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is both the address to claim and receive the rewards",
->>>>>>> 37fca3d (Update schemas)
-=======
         "description": "`WithdrawRewards` is a message sent by anyone on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is both the address to claim and receive the rewards. It's a Babylon address. If rewards are to be sent to a Consumer address, the staker's equivalent address in that chain will be computed and used.",
->>>>>>> fbd3b31 (Update schema)
         "type": "object",
         "required": [
           "withdraw_rewards"

--- a/contracts/btc-finality/schema/raw/execute.json
+++ b/contracts/btc-finality/schema/raw/execute.json
@@ -143,10 +143,14 @@
     },
     {
 <<<<<<< HEAD
+<<<<<<< HEAD
       "description": "`WithdrawRewards` is a message sent by the Babylon contract on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is the address to claim the rewards.",
 =======
       "description": "`WithdrawRewards` is a message sent by anyone on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is both the address to claim and receive the rewards",
 >>>>>>> 37fca3d (Update schemas)
+=======
+      "description": "`WithdrawRewards` is a message sent by anyone on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is both the address to claim and receive the rewards. It's a Babylon address. If rewards are to be sent to a Consumer address, the staker's equivalent address in that chain will be computed and used.",
+>>>>>>> fbd3b31 (Update schema)
       "type": "object",
       "required": [
         "withdraw_rewards"

--- a/contracts/btc-finality/schema/raw/execute.json
+++ b/contracts/btc-finality/schema/raw/execute.json
@@ -142,7 +142,11 @@
       "additionalProperties": false
     },
     {
+<<<<<<< HEAD
       "description": "`WithdrawRewards` is a message sent by the Babylon contract on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is the address to claim the rewards.",
+=======
+      "description": "`WithdrawRewards` is a message sent by anyone on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is both the address to claim and receive the rewards",
+>>>>>>> 37fca3d (Update schemas)
       "type": "object",
       "required": [
         "withdraw_rewards"

--- a/contracts/btc-finality/schema/raw/execute.json
+++ b/contracts/btc-finality/schema/raw/execute.json
@@ -142,15 +142,7 @@
       "additionalProperties": false
     },
     {
-<<<<<<< HEAD
-<<<<<<< HEAD
-      "description": "`WithdrawRewards` is a message sent by the Babylon contract on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is the address to claim the rewards.",
-=======
-      "description": "`WithdrawRewards` is a message sent by anyone on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is both the address to claim and receive the rewards",
->>>>>>> 37fca3d (Update schemas)
-=======
       "description": "`WithdrawRewards` is a message sent by anyone on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is both the address to claim and receive the rewards. It's a Babylon address. If rewards are to be sent to a Consumer address, the staker's equivalent address in that chain will be computed and used.",
->>>>>>> fbd3b31 (Update schema)
       "type": "object",
       "required": [
         "withdraw_rewards"

--- a/contracts/btc-finality/schema/raw/query.json
+++ b/contracts/btc-finality/schema/raw/query.json
@@ -241,7 +241,7 @@
       "additionalProperties": false
     },
     {
-      "description": "`PendingRewards` returns the pending rewards for a user on a finality provider. The rewards are returned in the form of a Coin",
+      "description": "`PendingRewards` returns the pending rewards for a staker on a finality provider. The staker address must be its Babylon delegator address. The rewards are returned in the form of a Coin.",
       "type": "object",
       "required": [
         "pending_rewards"
@@ -251,13 +251,13 @@
           "type": "object",
           "required": [
             "fp_pubkey_hex",
-            "user"
+            "staker_addr"
           ],
           "properties": {
             "fp_pubkey_hex": {
               "type": "string"
             },
-            "user": {
+            "staker_addr": {
               "type": "string"
             }
           },
@@ -267,7 +267,7 @@
       "additionalProperties": false
     },
     {
-      "description": "`AllPendingRewards` returns the pending rewards for a user on all finality providers.",
+      "description": "`AllPendingRewards` returns the pending rewards for a staker on all finality providers. The staker address must be its Babylon delegator address.",
       "type": "object",
       "required": [
         "all_pending_rewards"
@@ -276,7 +276,7 @@
         "all_pending_rewards": {
           "type": "object",
           "required": [
-            "user"
+            "staker_addr"
           ],
           "properties": {
             "limit": {
@@ -287,6 +287,9 @@
               "format": "uint32",
               "minimum": 0.0
             },
+            "staker_addr": {
+              "type": "string"
+            },
             "start_after": {
               "anyOf": [
                 {
@@ -296,9 +299,6 @@
                   "type": "null"
                 }
               ]
-            },
-            "user": {
-              "type": "string"
             }
           },
           "additionalProperties": false

--- a/contracts/btc-finality/src/contract.rs
+++ b/contracts/btc-finality/src/contract.rs
@@ -278,6 +278,7 @@ fn handle_end_block(
     Ok(res)
 }
 
+// Sends rewards to the staking contract for distribution over delegators
 fn send_rewards_msg(
     deps: &mut DepsMut,
     rewards: u128,

--- a/contracts/btc-finality/src/multitest.rs
+++ b/contracts/btc-finality/src/multitest.rs
@@ -441,7 +441,7 @@ mod distribution {
     use test_utils::get_public_randomness_commitment;
 
     #[test]
-    fn distribution_works() {
+    fn distribution_consumer_withdrawal_works() {
         // Read public randomness commitment test data
         let (pk_hex, pub_rand, pubrand_signature) = get_public_randomness_commitment();
         let pub_rand_one = get_pub_rand_value();
@@ -565,22 +565,19 @@ mod distribution {
         // distributed among delegators
         let rewards_denom = suite.get_btc_staking_config().denom;
         // Build staker 1 address on the Consumer network
+        let staker1_addr = del1.staker_addr;
         let staker1_addr_consumer = suite
-            .to_consumer_addr(&Addr::unchecked(del1.staker_addr.clone()))
+            .to_consumer_addr(&Addr::unchecked(staker1_addr.clone()))
             .unwrap();
+        let staker2_addr = del2.staker_addr;
 
-        let pending_rewards_1 = suite.get_pending_delegator_rewards(staker1_addr_consumer.as_str());
+        let pending_rewards_1 = suite.get_pending_delegator_rewards(&staker1_addr);
         assert_eq!(pending_rewards_1.len(), 1);
         assert_eq!(pending_rewards_1[0].fp_pubkey_hex, pk_hex);
         assert_eq!(pending_rewards_1[0].rewards.denom, rewards_denom);
         assert!(pending_rewards_1[0].rewards.amount.u128() > 0);
 
-        // Build staker 2 address on the Consumer network
-        let staker2_addr_consumer = suite
-            .to_consumer_addr(&Addr::unchecked(del2.staker_addr))
-            .unwrap();
-
-        let pending_rewards_2 = suite.get_pending_delegator_rewards(staker2_addr_consumer.as_str());
+        let pending_rewards_2 = suite.get_pending_delegator_rewards(staker2_addr.as_str());
         assert_eq!(pending_rewards_2.len(), 1);
         assert_eq!(pending_rewards_2[0].fp_pubkey_hex, new_fp2.btc_pk_hex);
         assert_eq!(pending_rewards_2[0].rewards.denom, rewards_denom);
@@ -601,17 +598,15 @@ mod distribution {
 
         // Trying to withdraw the rewards with a Babylon address should work
         suite
-            .withdraw_rewards(&new_fp1.btc_pk_hex, &del1.staker_addr)
+            .withdraw_rewards(&new_fp1.btc_pk_hex, &staker1_addr)
             .unwrap();
 
-        // Rewards have been transferred
-        let pending_rewards_1 = suite.get_pending_delegator_rewards(staker1_addr_consumer.as_str());
+        // Rewards have been transferred out of the staking contract
+        let pending_rewards_1 = suite.get_pending_delegator_rewards(staker1_addr.as_str());
         assert_eq!(pending_rewards_1.len(), 1);
         assert_eq!(pending_rewards_1[0].rewards.amount.u128(), 0);
 
-        // Rewards are now in the staker Consumer's address balance
-        println!("Staker 1 iconsumer address: {}", staker1_addr_consumer);
-        println!("Rewards denom: {}", rewards_denom);
+        // And are now in the staker (Consumer's) balance
         let consumer_balance = suite.get_balance(&staker1_addr_consumer, &rewards_denom);
         assert_eq!(consumer_balance.amount.u128(), rewards_1);
     }

--- a/contracts/btc-finality/src/multitest/suite.rs
+++ b/contracts/btc-finality/src/multitest/suite.rs
@@ -163,6 +163,11 @@ impl Suite {
         bech32_prefix
     }
 
+    #[track_caller]
+    pub fn get_balance(&self, addr: &Addr, denom: &str) -> Coin {
+        self.app.wrap().query_balance(addr, denom).unwrap()
+    }
+
     #[allow(dead_code)]
     pub fn admin(&self) -> &str {
         self.owner.as_str()
@@ -438,5 +443,22 @@ impl Suite {
             )
             .unwrap();
         rewards_response.rewards
+    }
+
+    #[track_caller]
+    pub fn withdraw_rewards(
+        &mut self,
+        fp_pubkey_hex: &str,
+        staker: &str,
+    ) -> anyhow::Result<AppResponse> {
+        self.app.execute_contract(
+            Addr::unchecked("anyone"),
+            self.staking.clone(),
+            &btc_staking::msg::ExecuteMsg::WithdrawRewards {
+                fp_pubkey_hex: fp_pubkey_hex.to_owned(),
+                staker_addr: staker.to_owned(),
+            },
+            &[],
+        )
     }
 }

--- a/contracts/btc-finality/src/multitest/suite.rs
+++ b/contracts/btc-finality/src/multitest/suite.rs
@@ -114,7 +114,7 @@ impl SuiteBuilder {
                     admin: Some(owner.to_string()),
                     consumer_name: Some("TestConsumer".to_string()),
                     consumer_description: Some("Test Consumer Description".to_string()),
-                    ics20_info: None,
+                    ics20_channel_id: None,
                 },
                 &[],
                 "babylon",

--- a/contracts/btc-finality/src/multitest/suite.rs
+++ b/contracts/btc-finality/src/multitest/suite.rs
@@ -114,7 +114,7 @@ impl SuiteBuilder {
                     admin: Some(owner.to_string()),
                     consumer_name: Some("TestConsumer".to_string()),
                     consumer_description: Some("Test Consumer Description".to_string()),
-                    transfer_info: None,
+                    ics20_info: None,
                 },
                 &[],
                 "babylon",

--- a/contracts/btc-finality/src/multitest/suite.rs
+++ b/contracts/btc-finality/src/multitest/suite.rs
@@ -436,7 +436,7 @@ impl Suite {
             .query_wasm_smart(
                 self.staking.clone(),
                 &btc_staking::msg::QueryMsg::AllPendingRewards {
-                    user: staker.into(),
+                    staker_addr: staker.into(),
                     start_after: None,
                     limit: None,
                 },

--- a/contracts/btc-staking/schema/btc-staking.json
+++ b/contracts/btc-staking/schema/btc-staking.json
@@ -232,10 +232,14 @@
       },
       {
 <<<<<<< HEAD
+<<<<<<< HEAD
         "description": "`WithdrawRewards` is a message sent by the Babylon contract on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is the address to claim the rewards.",
 =======
         "description": "`WithdrawRewards` is a message sent by anyone on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is both the address to claim and receive the rewards",
 >>>>>>> 37fca3d (Update schemas)
+=======
+        "description": "`WithdrawRewards` is a message sent by anyone on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is both the address to claim and receive the rewards. It's a Babylon address. If rewards are to be sent to a Consumer address, the staker's equivalent address in that chain will be computed and used.",
+>>>>>>> fbd3b31 (Update schema)
         "type": "object",
         "required": [
           "withdraw_rewards"
@@ -919,7 +923,7 @@
         "additionalProperties": false
       },
       {
-        "description": "`PendingRewards` returns the pending rewards for a user on a finality provider. The rewards are returned in the form of a Coin",
+        "description": "`PendingRewards` returns the pending rewards for a staker on a finality provider. The staker address must be its Babylon delegator address. The rewards are returned in the form of a Coin.",
         "type": "object",
         "required": [
           "pending_rewards"
@@ -929,13 +933,13 @@
             "type": "object",
             "required": [
               "fp_pubkey_hex",
-              "user"
+              "staker_addr"
             ],
             "properties": {
               "fp_pubkey_hex": {
                 "type": "string"
               },
-              "user": {
+              "staker_addr": {
                 "type": "string"
               }
             },
@@ -945,7 +949,7 @@
         "additionalProperties": false
       },
       {
-        "description": "`AllPendingRewards` returns the pending rewards for a user on all finality providers.",
+        "description": "`AllPendingRewards` returns the pending rewards for a staker on all finality providers. The staker address must be its Babylon delegator address.",
         "type": "object",
         "required": [
           "all_pending_rewards"
@@ -954,7 +958,7 @@
           "all_pending_rewards": {
             "type": "object",
             "required": [
-              "user"
+              "staker_addr"
             ],
             "properties": {
               "limit": {
@@ -965,6 +969,9 @@
                 "format": "uint32",
                 "minimum": 0.0
               },
+              "staker_addr": {
+                "type": "string"
+              },
               "start_after": {
                 "anyOf": [
                   {
@@ -974,9 +981,6 @@
                     "type": "null"
                   }
                 ]
-              },
-              "user": {
-                "type": "string"
               }
             },
             "additionalProperties": false

--- a/contracts/btc-staking/schema/btc-staking.json
+++ b/contracts/btc-staking/schema/btc-staking.json
@@ -231,7 +231,11 @@
         "additionalProperties": false
       },
       {
+<<<<<<< HEAD
         "description": "`WithdrawRewards` is a message sent by the Babylon contract on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is the address to claim the rewards.",
+=======
+        "description": "`WithdrawRewards` is a message sent by anyone on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is both the address to claim and receive the rewards",
+>>>>>>> 37fca3d (Update schemas)
         "type": "object",
         "required": [
           "withdraw_rewards"

--- a/contracts/btc-staking/schema/btc-staking.json
+++ b/contracts/btc-staking/schema/btc-staking.json
@@ -231,15 +231,7 @@
         "additionalProperties": false
       },
       {
-<<<<<<< HEAD
-<<<<<<< HEAD
-        "description": "`WithdrawRewards` is a message sent by the Babylon contract on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is the address to claim the rewards.",
-=======
-        "description": "`WithdrawRewards` is a message sent by anyone on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is both the address to claim and receive the rewards",
->>>>>>> 37fca3d (Update schemas)
-=======
         "description": "`WithdrawRewards` is a message sent by anyone on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is both the address to claim and receive the rewards. It's a Babylon address. If rewards are to be sent to a Consumer address, the staker's equivalent address in that chain will be computed and used.",
->>>>>>> fbd3b31 (Update schema)
         "type": "object",
         "required": [
           "withdraw_rewards"

--- a/contracts/btc-staking/schema/raw/execute.json
+++ b/contracts/btc-staking/schema/raw/execute.json
@@ -143,10 +143,14 @@
     },
     {
 <<<<<<< HEAD
+<<<<<<< HEAD
       "description": "`WithdrawRewards` is a message sent by the Babylon contract on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is the address to claim the rewards.",
 =======
       "description": "`WithdrawRewards` is a message sent by anyone on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is both the address to claim and receive the rewards",
 >>>>>>> 37fca3d (Update schemas)
+=======
+      "description": "`WithdrawRewards` is a message sent by anyone on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is both the address to claim and receive the rewards. It's a Babylon address. If rewards are to be sent to a Consumer address, the staker's equivalent address in that chain will be computed and used.",
+>>>>>>> fbd3b31 (Update schema)
       "type": "object",
       "required": [
         "withdraw_rewards"

--- a/contracts/btc-staking/schema/raw/execute.json
+++ b/contracts/btc-staking/schema/raw/execute.json
@@ -142,7 +142,11 @@
       "additionalProperties": false
     },
     {
+<<<<<<< HEAD
       "description": "`WithdrawRewards` is a message sent by the Babylon contract on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is the address to claim the rewards.",
+=======
+      "description": "`WithdrawRewards` is a message sent by anyone on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is both the address to claim and receive the rewards",
+>>>>>>> 37fca3d (Update schemas)
       "type": "object",
       "required": [
         "withdraw_rewards"

--- a/contracts/btc-staking/schema/raw/execute.json
+++ b/contracts/btc-staking/schema/raw/execute.json
@@ -142,15 +142,7 @@
       "additionalProperties": false
     },
     {
-<<<<<<< HEAD
-<<<<<<< HEAD
-      "description": "`WithdrawRewards` is a message sent by the Babylon contract on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is the address to claim the rewards.",
-=======
-      "description": "`WithdrawRewards` is a message sent by anyone on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is both the address to claim and receive the rewards",
->>>>>>> 37fca3d (Update schemas)
-=======
       "description": "`WithdrawRewards` is a message sent by anyone on behalf of the staker, to withdraw rewards from BTC staking via the given FP.\n\n`staker_addr` is both the address to claim and receive the rewards. It's a Babylon address. If rewards are to be sent to a Consumer address, the staker's equivalent address in that chain will be computed and used.",
->>>>>>> fbd3b31 (Update schema)
       "type": "object",
       "required": [
         "withdraw_rewards"

--- a/contracts/btc-staking/schema/raw/query.json
+++ b/contracts/btc-staking/schema/raw/query.json
@@ -241,7 +241,7 @@
       "additionalProperties": false
     },
     {
-      "description": "`PendingRewards` returns the pending rewards for a user on a finality provider. The rewards are returned in the form of a Coin",
+      "description": "`PendingRewards` returns the pending rewards for a staker on a finality provider. The staker address must be its Babylon delegator address. The rewards are returned in the form of a Coin.",
       "type": "object",
       "required": [
         "pending_rewards"
@@ -251,13 +251,13 @@
           "type": "object",
           "required": [
             "fp_pubkey_hex",
-            "user"
+            "staker_addr"
           ],
           "properties": {
             "fp_pubkey_hex": {
               "type": "string"
             },
-            "user": {
+            "staker_addr": {
               "type": "string"
             }
           },
@@ -267,7 +267,7 @@
       "additionalProperties": false
     },
     {
-      "description": "`AllPendingRewards` returns the pending rewards for a user on all finality providers.",
+      "description": "`AllPendingRewards` returns the pending rewards for a staker on all finality providers. The staker address must be its Babylon delegator address.",
       "type": "object",
       "required": [
         "all_pending_rewards"
@@ -276,7 +276,7 @@
         "all_pending_rewards": {
           "type": "object",
           "required": [
-            "user"
+            "staker_addr"
           ],
           "properties": {
             "limit": {
@@ -287,6 +287,9 @@
               "format": "uint32",
               "minimum": 0.0
             },
+            "staker_addr": {
+              "type": "string"
+            },
             "start_after": {
               "anyOf": [
                 {
@@ -296,9 +299,6 @@
                   "type": "null"
                 }
               ]
-            },
-            "user": {
-              "type": "string"
             }
           },
           "additionalProperties": false

--- a/contracts/btc-staking/src/contract.rs
+++ b/contracts/btc-staking/src/contract.rs
@@ -153,7 +153,7 @@ pub fn execute(
             fp_pubkey_hex,
             staker_addr,
         } => {
-            let res = handle_withdraw_rewards(deps, &info, &fp_pubkey_hex, staker_addr)?;
+            let res = handle_withdraw_rewards(deps, &env, &info, &fp_pubkey_hex, staker_addr)?;
             Ok(res)
         }
     }

--- a/contracts/btc-staking/src/contract.rs
+++ b/contracts/btc-staking/src/contract.rs
@@ -90,20 +90,20 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<QueryResponse, Cont
             &queries::finality_providers_by_power(deps, start_after, limit)?,
         )?),
         QueryMsg::PendingRewards {
-            user,
+            staker_addr,
             fp_pubkey_hex,
         } => Ok(to_json_binary(&queries::pending_rewards(
             deps,
-            user,
+            staker_addr,
             fp_pubkey_hex,
         )?)?),
         QueryMsg::AllPendingRewards {
-            user,
+            staker_addr,
             start_after,
             limit,
         } => Ok(to_json_binary(&queries::all_pending_rewards(
             deps,
-            user,
+            staker_addr,
             start_after,
             limit,
         )?)?),

--- a/contracts/btc-staking/src/msg.rs
+++ b/contracts/btc-staking/src/msg.rs
@@ -86,14 +86,19 @@ pub enum QueryMsg {
         start_after: Option<FinalityProviderInfo>,
         limit: Option<u32>,
     },
-    /// `PendingRewards` returns the pending rewards for a user on a finality provider.
-    /// The rewards are returned in the form of a Coin
+    /// `PendingRewards` returns the pending rewards for a staker on a finality provider.
+    /// The staker address must be its Babylon delegator address.
+    /// The rewards are returned in the form of a Coin.
     #[returns(PendingRewardsResponse)]
-    PendingRewards { user: String, fp_pubkey_hex: String },
-    /// `AllPendingRewards` returns the pending rewards for a user on all finality providers.
+    PendingRewards {
+        staker_addr: String,
+        fp_pubkey_hex: String,
+    },
+    /// `AllPendingRewards` returns the pending rewards for a staker on all finality providers.
+    /// The staker address must be its Babylon delegator address.
     #[returns(AllPendingRewardsResponse)]
     AllPendingRewards {
-        user: String,
+        staker_addr: String,
         start_after: Option<PendingRewards>,
         limit: Option<u32>,
     },

--- a/contracts/btc-staking/src/staking.rs
+++ b/contracts/btc-staking/src/staking.rs
@@ -489,6 +489,8 @@ pub fn handle_withdraw_rewards(
     Ok(resp)
 }
 
+/// `send_rewards_msg` sends the rewards to either the staker address on the Consumer or on Babylon,
+/// depending on the ICS-20 transfer info queried from the Babylon contract.
 fn send_rewards_msg(
     deps: &DepsMut,
     env: &Env,
@@ -504,7 +506,7 @@ fn send_rewards_msg(
         &babylon_contract::msg::contract::QueryMsg::TransferInfo {},
     )?;
 
-    // Create the bank / routing packet
+    // Create the corresponding bank or transfer packet
     let (recipient, cosmos_msg) = match transfer_info {
         None => {
             // Consumer withdrawal.

--- a/contracts/btc-staking/src/staking.rs
+++ b/contracts/btc-staking/src/staking.rs
@@ -510,12 +510,11 @@ fn send_rewards_msg(
             // Consumer withdrawal.
             // Send rewards to the staker address on the Consumer
             let recipient = deps.api.addr_humanize(staker_canonical_addr)?.to_string();
-            let msg = BankMsg::Send {
+            let bank_msg = BankMsg::Send {
                 to_address: recipient.clone(),
                 amount: vec![coin(amount.u128(), cfg.denom)],
             };
-            let wasm_msg = CosmosMsg::Bank(msg);
-            (recipient, wasm_msg)
+            (recipient, CosmosMsg::Bank(bank_msg))
         }
         Some(ics20_channel_id) => {
             // Babylon withdrawal.

--- a/contracts/btc-staking/tests/integration.rs
+++ b/contracts/btc-staking/tests/integration.rs
@@ -6,7 +6,7 @@ use btc_staking::msg::InstantiateMsg;
 // wasm binary lite version
 static WASM: &[u8] = include_bytes!("../../../artifacts/btc_staking.wasm");
 /// Wasm size limit: https://github.com/CosmWasm/wasmd/blob/main/x/wasm/types/validation.go#L24-L25
-const MAX_WASM_SIZE: usize = 800 * 1024; // 800 KB
+const MAX_WASM_SIZE: usize = 1024 * 1024; // 1 MB
 
 // wasm binary with full validation
 static WASM_FULL: &[u8] = include_bytes!("../../../artifacts/btc_staking-full-validation.wasm");

--- a/packages/apis/src/btc_staking_api.rs
+++ b/packages/apis/src/btc_staking_api.rs
@@ -35,10 +35,10 @@ pub enum ExecuteMsg {
         /// `fp_distribution` is the list of finality providers and their rewards
         fp_distribution: Vec<RewardInfo>,
     },
-    /// `WithdrawRewards` is a message sent by the Babylon contract on behalf of the
+    /// `WithdrawRewards` is a message sent by anyone on behalf of the
     /// staker, to withdraw rewards from BTC staking via the given FP.
     ///
-    /// `staker_addr` is the address to claim the rewards.
+    /// `staker_addr` is both the address to claim and receive the rewards
     WithdrawRewards {
         fp_pubkey_hex: String,
         staker_addr: String,

--- a/packages/apis/src/btc_staking_api.rs
+++ b/packages/apis/src/btc_staking_api.rs
@@ -38,7 +38,9 @@ pub enum ExecuteMsg {
     /// `WithdrawRewards` is a message sent by anyone on behalf of the
     /// staker, to withdraw rewards from BTC staking via the given FP.
     ///
-    /// `staker_addr` is both the address to claim and receive the rewards
+    /// `staker_addr` is both the address to claim and receive the rewards.
+    /// It's a Babylon address. If rewards are to be sent to a Consumer address, the
+    /// staker's equivalent address in that chain will be computed and used.
     WithdrawRewards {
         fp_pubkey_hex: String,
         staker_addr: String,


### PR DESCRIPTION
Rewards withdrawal to a Babylon address. Depending on the ICS-020 channel information being set or not during contract instantiation.

#102 follow-up / complement. Tracking issue: https://github.com/babylonlabs-io/pm/issues/114.

**TODO**:

- [x] Update relevant [ADR](https://github.com/babylonlabs-io/pm/pull/150).
- [x] Test rewards withdrawal to a Consumer address.
- [x] ~Test rewards withdrawal to a Babylon address~ (to be done as part of e2e tests).