### PR TITLE
Generalise testdata folder location finding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,38 +655,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "camino"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3112,7 +3080,6 @@ dependencies = [
  "babylon-apis",
  "babylon-bitcoin",
  "babylon-proto",
- "cargo_metadata",
  "cosmwasm-std",
  "hex",
  "k256",

--- a/packages/test-utils/Cargo.toml
+++ b/packages/test-utils/Cargo.toml
@@ -11,7 +11,6 @@ publish.workspace = true
 babylon-apis     = { path = "../apis" }
 babylon-proto    = { path = "../proto" }
 babylon-bitcoin  = { path = "../bitcoin" }
-cargo_metadata   = { workspace = true }
 cosmwasm-std     = { workspace = true }
 hex              = { workspace = true }
 k256             = { workspace = true }

--- a/packages/test-utils/src/lib.rs
+++ b/packages/test-utils/src/lib.rs
@@ -1,4 +1,3 @@
-use cargo_metadata::MetadataCommand;
 use hex::ToHex;
 use k256::schnorr::{Signature, SigningKey};
 use prost::{bytes::Bytes, Message};
@@ -40,32 +39,12 @@ const ADD_FINALITY_SIG_DATA: &str = "add_finality_sig_{}_msg.dat";
 
 const EOTS_DATA: &str = "eots_testdata.json";
 
-pub fn find_project_path() -> Option<PathBuf> {
-    PathBuf::from(file!())
-        .parent()
-        .and_then(|p| p.parent())
-        .map(|p| p.to_path_buf())
-}
-
-fn find_workspace_root() -> PathBuf {
-    // Get the current working directory
-    let cwd = env::current_dir().unwrap();
-
-    // Use cargo_metadata to find the root manifest for the workspace
-    let mut metadata_cmd = MetadataCommand::new();
-    let metadata = metadata_cmd.current_dir(cwd).no_deps().exec().unwrap();
-    metadata.workspace_root.into_std_path_buf()
+pub fn find_project_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
 fn find_testdata_path() -> PathBuf {
-    let project_path = find_project_path().unwrap_or(PathBuf::from("packages/test-utils"));
-    let project_path = if project_path.is_relative() {
-        let workspace_root = find_workspace_root();
-        workspace_root.join(project_path)
-    } else {
-        project_path
-    };
-    project_path.join("testdata")
+    find_project_path().join("testdata")
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/packages/test-utils/src/lib.rs
+++ b/packages/test-utils/src/lib.rs
@@ -40,6 +40,13 @@ const ADD_FINALITY_SIG_DATA: &str = "add_finality_sig_{}_msg.dat";
 
 const EOTS_DATA: &str = "eots_testdata.json";
 
+pub fn find_project_path() -> Option<PathBuf> {
+    PathBuf::from(file!())
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|p| p.to_path_buf())
+}
+
 fn find_workspace_root() -> PathBuf {
     // Get the current working directory
     let cwd = env::current_dir().unwrap();
@@ -51,10 +58,14 @@ fn find_workspace_root() -> PathBuf {
 }
 
 fn find_testdata_path() -> PathBuf {
-    find_workspace_root()
-        .join("packages")
-        .join("test-utils")
-        .join("testdata")
+    let project_path = find_project_path().unwrap_or(PathBuf::from("packages/test-utils"));
+    let project_path = if project_path.is_relative() {
+        let workspace_root = find_workspace_root();
+        workspace_root.join(project_path)
+    } else {
+        project_path
+    };
+    project_path.join("testdata")
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
Generalise `test-utils` `testdata/` folder finding, so that `test-utils` can also be used as a non-local dependency (i.e. from the new https://github.com/babylonlabs-io/op-finality-gadget repo).

**TODO**:

- [ ] Publish the reference / API packages under `packages/` to [crates.io](https://crates.io/).
- [ ] Use those as deps in `op-finality-gadget`.